### PR TITLE
fix: ignore non-200 propstat elements in WebDAV response

### DIFF
--- a/src/client/core.rs
+++ b/src/client/core.rs
@@ -563,6 +563,14 @@ impl RustyClient {
                 if name.eq_ignore_ascii_case("href") {
                     href = child.text().unwrap_or("").to_string();
                 } else if name.eq_ignore_ascii_case("propstat") {
+                    let is_200 = child.children().any(|c| {
+                        c.tag_name().name().eq_ignore_ascii_case("status")
+                            && c.text().map(|s| s.contains("200")).unwrap_or(false)
+                    });
+                    if !is_200 {
+                        continue;
+                    }
+
                     for propstat_child in child.children() {
                         if propstat_child
                             .tag_name()


### PR DESCRIPTION
### Problem

When connecting to CalDAV servers that return multiple `<D:propstat>` elements (such as [Vikunja](https://github.com/go-vikunja/vikunja), which returns `200 OK` for supported properties and `404 Not Found` for unsupported ones like `<D:current-user-privilege-set/>`), all discovered calendars were silently discarded. This left the Calendars sidebar and task view completely empty.

### Root Cause

In `RustyClient::perform_calendar_discovery` (`src/client/core.rs`), the XML parser iterated over all `<propstat>` elements without verifying that the child `<status>` element was `HTTP/1.1 200 OK`.
When encountering a `404 Not Found``<propstat>` block containing an empty `<current-user-privilege-set/>`, `has_privilege_set` was set to `true`. Because the 404 tag contained no `<privilege>` children, `can_write` remained `false`. The calendar was then rejected by the `if is_calendar && can_write && supports_vtodo` filter.

### Solution

Added a status check in `perform_calendar_discovery` to skip `<propstat>` elements whose status does not contain `200`. If `<current-user-privilege-set>` is not present in a `200 OK` block, the client correctly falls back to assuming write access (`can_write = true`).

### Validation

- [x] Tested against a Vikunja CalDAV server; collections and tasks now discover and sync properly.
- [x] Ran `cargo fmt --all -- --check`
- [x] Ran `cargo clippy --all-features --all-targets` (clean)
- [x] Ran `cargo test --all-features --all-targets` (all 411 tests passed)